### PR TITLE
Change sagittarius translation in pt-BR

### DIFF
--- a/src/lang/pt-BR/zodiacs.php
+++ b/src/lang/pt-BR/zodiacs.php
@@ -9,7 +9,7 @@ return [
     'virgo' => 'Virgem',
     'libra' => 'Libra',
     'scorpio' => 'Escorpião',
-    'sagittarius' => 'Sargitário',
+    'sagittarius' => 'Sagitário',
     'capricorn' => 'Capricórnio',
     'aquarius' => 'Aquário',
     'pisces' => 'Peixes'


### PR DESCRIPTION
In Brazilian Portuguese, the correct translation of sagittarius is 'Sagitário' instead of 'Sargitário'.